### PR TITLE
Changed color for ant-result-subtitle

### DIFF
--- a/src/nz-zorro.scss
+++ b/src/nz-zorro.scss
@@ -28746,7 +28746,7 @@ nz-tree {
     text-align: center;
 }
 .ant-result-subtitle {
-    color: rgba(0, 0, 0, 0.45);
+    color: #777;
     font-size: 14px;
     line-height: 1.6;
     text-align: center;


### PR DESCRIPTION
Changed the color for ant-result-subtitle that is used for the 404 page (under app/fallback) to be more visible for dark mode users.